### PR TITLE
Removing 'blank5'

### DIFF
--- a/apps/blank5/app.yml
+++ b/apps/blank5/app.yml
@@ -1,6 +1,0 @@
-version: 43.0.9
-pageUuid: 1485db1a-d165-11ec-bbd9-9bddb8c8c06f
-appTemplate:
-  rootScreen: null
-  version: 2.91.8
-  markdownLinkBehavior: auto


### PR DESCRIPTION
### Removing 'blank5'

This PR will remove the application from the Retool Source Control repository.

Preview application here: http://localhost:3000/apps/blank5
