### PR TITLE
Removing 'blank4'

### DIFF
--- a/apps/blank4/app.yml
+++ b/apps/blank4/app.yml
@@ -1,6 +1,0 @@
-version: 43.0.9
-pageUuid: 932a4aee-d0bd-11ec-a0ca-d758e2a74ae6
-appTemplate:
-  rootScreen: null
-  version: 2.91.7
-  markdownLinkBehavior: auto


### PR DESCRIPTION
### Removing 'blank4'

This PR will remove the application from the Retool Source Control repository.

Preview application here: http://localhost:3000/apps/blank4
