### PR TITLE
Removing 'blank3'

### DIFF
--- a/apps/blank3/app.yml
+++ b/apps/blank3/app.yml
@@ -1,6 +1,0 @@
-version: 43.0.9
-pageUuid: 4fb81eb8-d09e-11ec-b914-0382a3953d09
-appTemplate:
-  rootScreen: null
-  version: 2.91.7
-  markdownLinkBehavior: auto


### PR DESCRIPTION
### Removing 'blank3'

This PR will remove the application from the Retool Source Control repository.

Preview application here: http://localhost:3000/apps/blank3
