### PR TITLE
Removing 'asdf - naming conflict at Jul 4, 2023 6:05 AM'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+
+**/*.rsx linguist-language=TSX
+**/.positions.json linguist-generated=true
+**/.mobile_positions.json linguist-generated=true
+**/.defaults.json linguist-generated=true


### PR DESCRIPTION
### Removing 'asdf - naming conflict at Jul 4, 2023 6:05 AM'

This PR will remove the application from the Retool Source Control repository.

Preview application here: http://localhost:3000/apps/asdf%20-%20naming%20conflict%20at%20Jul%204%2C%202023%206%3A05%20AM
